### PR TITLE
Added an ebuild for intellimouse-ctl, so now you can have Gentoo instructions again if you want

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ cd intellimouse-ctl
 pip install .
 ```
 
+### Gentoo Linux
+```layman -fa fol4    (or eselect repository enable fol4)
+emerge -av intellimouse-ctl
+```
+
 ## Development
 To set up a virtual environment to further develop this tool/library, use the following commands:
 ```bash

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ pip install .
 ```
 
 ### Gentoo Linux
-```layman -fa fol4    (or eselect repository enable fol4)
+```bash
+layman -fa fol4    (or eselect repository enable fol4)
 emerge -av intellimouse-ctl
 ```
 


### PR DESCRIPTION
The package makes it a system package so it'll be available system wide as /usr/bin/intellimouse-ctl